### PR TITLE
Modified keys in ruby armour recipes to map correctly

### DIFF
--- a/src/main/resources/data/emerald_tools/recipes/ruby_boots.json
+++ b/src/main/resources/data/emerald_tools/recipes/ruby_boots.json
@@ -6,7 +6,7 @@
     "r r"
   ],
   "key": {
-    "e": {
+    "r": {
       "item": "emerald_tools:ruby"
     }
   },

--- a/src/main/resources/data/emerald_tools/recipes/ruby_chestplate.json
+++ b/src/main/resources/data/emerald_tools/recipes/ruby_chestplate.json
@@ -6,7 +6,7 @@
     "rrr"
   ],
   "key": {
-    "e": {
+    "r": {
       "item": "emerald_tools:ruby"
     }
   },

--- a/src/main/resources/data/emerald_tools/recipes/ruby_helmet.json
+++ b/src/main/resources/data/emerald_tools/recipes/ruby_helmet.json
@@ -6,7 +6,7 @@
     "   "
   ],
   "key": {
-    "e": {
+    "r": {
       "item": "emerald_tools:ruby"
     }
   },

--- a/src/main/resources/data/emerald_tools/recipes/ruby_leggings.json
+++ b/src/main/resources/data/emerald_tools/recipes/ruby_leggings.json
@@ -6,7 +6,7 @@
     "r r"
   ],
   "key": {
-    "e": {
+    "r": {
       "item": "emerald_tools:ruby"
     }
   },


### PR DESCRIPTION
Hi,

Thanks for this mod, I'm really enjoying it.

I was having an issue with the ruby armour where it was uncraftable in both the 20w16a and 20w17a versions, the logs indicated that the issue was in the recipe files, it looks like the keys just didn't match the crafting recipe. 

Thanks